### PR TITLE
Initialized `priceResponse` variable

### DIFF
--- a/tampermonkey-ai-sbc.user.js
+++ b/tampermonkey-ai-sbc.user.js
@@ -861,8 +861,9 @@
 			const futBinResponse = await makeGetRequest(
 				`https://www.futbin.com/24/playerPrices?player=${primaryId}&rids=${refIds}`
 			);
+			let priceResponse = 0;
 			try {
-				const priceResponse = JSON.parse(futBinResponse);
+				priceResponse = JSON.parse(futBinResponse);
 			} catch (error) {
 				console.log(futBinResponse);
 				console.error(error);


### PR DESCRIPTION
It was giving an error because `priceResponse` variable is not defined in line 873:
`const prices = priceResponse[id].prices[getUserPlatform()];`

Fixed by initializing that variable.